### PR TITLE
Reposition copy affordance next to OCR text

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/dictionary/components/DictionaryComponents.kt
+++ b/app/src/main/java/eu/kanade/presentation/dictionary/components/DictionaryComponents.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.LibraryAddCheck
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -85,6 +86,7 @@ fun DictionaryResults(
     onTermClick: (DictionaryTerm) -> Unit,
     onQueryChange: (String) -> Unit,
     onSearch: (String) -> Unit,
+    onCopyText: (() -> Unit)? = null,
     onOpenDictionarySettings: (() -> Unit)? = null,
     contentPadding: PaddingValues = PaddingValues(16.dp),
 ) {
@@ -127,6 +129,7 @@ fun DictionaryResults(
                         highlightRange = null,
                         onSearch = { onSearch(it) },
                         modifier = Modifier.padding(contentPadding),
+                        onTrailingAction = onCopyText,
                     )
                 }
                 EmptyScreen(
@@ -144,6 +147,7 @@ fun DictionaryResults(
                 onTermClick = onTermClick,
                 onQueryChange = onQueryChange,
                 onSearch = onSearch,
+                onCopyText = onCopyText,
                 query = query,
                 highlightRange = highlightRange,
                 contentPadding = contentPadding,
@@ -189,6 +193,7 @@ private fun SearchResultsList(
     onTermClick: (DictionaryTerm) -> Unit,
     onQueryChange: (String) -> Unit,
     onSearch: (String) -> Unit,
+    onCopyText: (() -> Unit)? = null,
     query: String,
     highlightRange: Pair<Int, Int>?,
     modifier: Modifier = Modifier,
@@ -205,6 +210,7 @@ private fun SearchResultsList(
                     text = query,
                     highlightRange = highlightRange,
                     onSearch = { onSearch(it) },
+                    onTrailingAction = onCopyText,
                 )
             }
         }
@@ -458,6 +464,7 @@ private fun WordSelector(
     highlightRange: Pair<Int, Int>? = null,
     onSearch: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onTrailingAction: (() -> Unit)? = null,
 ) {
     // OCR text header - clickable to search from any character
     var layout by remember { mutableStateOf<TextLayoutResult?>(null) }
@@ -486,27 +493,42 @@ private fun WordSelector(
         }
     }
 
-    Text(
-        text = annotatedString,
-        style = MaterialTheme.typography.titleMedium.copy(
-            fontSize = 20.sp,
-            color = MaterialTheme.colorScheme.onSurface,
-            letterSpacing = 2.sp,
-            fontWeight = FontWeight.Normal,
-        ),
-        onTextLayout = { layout = it },
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = 4.dp)
-            .pointerInput(text) {
-                detectTapGestures { pos ->
-                    layout?.let { layoutResult ->
-                        val offset = layoutResult.getOffsetForPosition(pos)
-                        if (offset < text.length) {
-                            onSearch(text.substring(offset))
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = annotatedString,
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontSize = 20.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+                letterSpacing = 2.sp,
+                fontWeight = FontWeight.Normal,
+            ),
+            onTextLayout = { layout = it },
+            modifier = Modifier
+                .weight(1f)
+                .padding(vertical = 4.dp)
+                .pointerInput(text) {
+                    detectTapGestures { pos ->
+                        layout?.let { layoutResult ->
+                            val offset = layoutResult.getOffsetForPosition(pos)
+                            if (offset < text.length) {
+                                onSearch(text.substring(offset))
+                            }
                         }
                     }
-                }
-            },
-    )
+                },
+        )
+
+        if (onTrailingAction != null) {
+            IconButton(onClick = onTrailingAction) {
+                Icon(
+                    imageVector = Icons.Outlined.ContentCopy,
+                    contentDescription = stringResource(MR.strings.action_copy),
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/eu/kanade/presentation/reader/OcrResultBottomSheet.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/OcrResultBottomSheet.kt
@@ -4,16 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ContentCopy
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -30,7 +25,6 @@ import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.ResizableSheet
 import tachiyomi.presentation.core.components.SheetValue
 import tachiyomi.presentation.core.components.material.padding
-import tachiyomi.presentation.core.i18n.stringResource
 
 private const val SHEET_EXPANSION_THRESHOLD = 0.80f
 
@@ -80,30 +74,12 @@ fun OcrResultBottomSheet(
                     verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
                 ) {
                     if (isSheetExpanded) {
-                        Row(
+                        SearchBar(
+                            query = searchState.query,
+                            onQueryChange = onQueryChange,
+                            onSearch = { onSearch(searchState.query) },
                             modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            SearchBar(
-                                query = searchState.query,
-                                onQueryChange = onQueryChange,
-                                onSearch = { onSearch(searchState.query) },
-                                modifier = Modifier.weight(1f),
-                            )
-
-                            FilledTonalButton(
-                                onClick = {
-                                    onCopyText()
-                                },
-                                contentPadding = PaddingValues(vertical = 12.dp, horizontal = 12.dp),
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Outlined.ContentCopy,
-                                    contentDescription = stringResource(MR.strings.action_copy),
-                                )
-                            }
-                        }
+                        )
 
                         HorizontalDivider()
                     }
@@ -123,6 +99,7 @@ fun OcrResultBottomSheet(
                         onTermClick = onTermClick,
                         onQueryChange = onQueryChange,
                         onSearch = onSearch,
+                        onCopyText = onCopyText,
                         contentPadding = PaddingValues(bottom = 8.dp),
                     )
                 }


### PR DESCRIPTION
Closes https://github.com/yomihon/yomihon/issues/14

### Motivation
- Make the OCR copy affordance always accessible next to the displayed OCR text instead of only inside the expanded sheet header so users can copy OCR text more easily.

### Description
- Extended `DictionaryResults` and `SearchResultsList` to accept an optional `onCopyText` callback and threaded it into the UI call chain.
- Updated `WordSelector` to accept an optional trailing action `onTrailingAction` and render an `IconButton` using `Icons.Outlined.ContentCopy` and `MR.strings.action_copy` when provided.
- Rendered the copy icon next to the OCR header in both the results list and empty-results branches by supplying `onTrailingAction = onCopyText` to the `WordSelector` usage.
- Simplified `OcrResultBottomSheet` expanded header to only show the search input and passed `onCopyText` into `DictionaryResults`, removing the previous dependency on `isSheetExpanded` for exposing copy functionality.
- Key files changed: `DictionaryComponents.kt` and `OcrResultBottomSheet.kt`.

<img width="639" height="1280" alt="image" src="https://github.com/user-attachments/assets/d102b7a4-2eb6-4ffc-986b-3cdc29858b00" />
