### PR TITLE
Add DevContainer Android development support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ARG CMDLINE_TOOLS_VERSION=11076708
+ARG ANDROID_SDK_ROOT=/opt/android-sdk
+
+ENV ANDROID_HOME=${ANDROID_SDK_ROOT}
+ENV ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}
+ENV PATH=${PATH}:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:${ANDROID_SDK_ROOT}/platform-tools
+
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg unzip wget \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public \
+        | gpg --dearmor -o /etc/apt/keyrings/adoptium.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print $2}' /etc/os-release) main" \
+        > /etc/apt/sources.list.d/adoptium.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends temurin-17-jdk \
+    && ln -sf /usr/lib/jvm/temurin-17-jdk-$(dpkg --print-architecture) /usr/lib/jvm/temurin-17-jdk-current \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/temurin-17-jdk-current
+ENV GRADLE_USER_HOME=/home/vscode/.gradle
+
+RUN mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools ${ANDROID_SDK_ROOT}/platform-tools \
+    && wget -q https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip -O /tmp/cmdline-tools.zip \
+    && unzip -q /tmp/cmdline-tools.zip -d /tmp/android-cmdline-tools \
+    && mv /tmp/android-cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/latest \
+    && yes | sdkmanager --sdk_root=${ANDROID_SDK_ROOT} --licenses > /dev/null \
+    && sdkmanager --sdk_root=${ANDROID_SDK_ROOT} \
+        "platform-tools" \
+        "build-tools;35.0.1" \
+        "platforms;android-35" \
+        "platforms;android-36" \
+        "ndk;27.1.12297006" \
+    && chown -R vscode:vscode ${ANDROID_SDK_ROOT} \
+    && rm -rf /tmp/android-cmdline-tools /tmp/cmdline-tools.zip

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,104 @@
+# Android DevContainer workflow
+
+This repository includes a DevContainer setup for Android development on macOS without installing the Android toolchain on the host.
+
+## What lives where
+
+- Host: Docker Desktop and VS Code with the Dev Containers extension
+- Container: Java 17, Android SDK, build tools, NDK, Gradle
+- Phone: ADB wireless debugging over Wi-Fi
+
+## Repo-local state that is persisted
+
+- `.gradle-cache/` keeps Gradle downloads between container rebuilds
+- `.android-adb/` keeps ADB client keys and wireless pairing state between container rebuilds
+
+Both directories are gitignored and are created automatically when VS Code starts the container.
+
+## First open
+
+1. Open the repository in VS Code.
+2. Run `Dev Containers: Reopen in Container`.
+3. Wait for the image build to finish.
+
+The container image installs the SDK pieces this repo currently needs:
+
+- Java 17
+- Android platform `36`
+- Android platform `35`
+- Build tools `35.0.1`
+- NDK `27.1.12297006`
+- `platform-tools`
+
+`local.properties` is also written automatically inside the workspace with `sdk.dir=/opt/android-sdk`.
+
+On Apple Silicon Macs, this container should run as `linux/amd64`. In practice, the official Android Linux toolchain used by Gradle, including `adb` and `aapt2` from the SDK packages, is x86_64-only. Keeping the whole container on one architecture avoids mixed-architecture failures during resource processing and packaging.
+
+## Pair a phone the first time
+
+Requirements:
+
+- Android 11 or later
+- Developer options enabled
+- Wireless debugging enabled
+- Phone and Mac on the same Wi-Fi network
+
+On the phone:
+
+1. Open `Settings -> Developer options -> Wireless debugging`.
+2. Tap `Pair device with pairing code`.
+3. Note the pairing address and six-digit PIN.
+
+In the container terminal:
+
+```bash
+./scripts/adb-wireless pair 192.168.1.50:37895
+```
+
+Enter the PIN when prompted.
+
+Because `/home/vscode/.android` is backed by `.android-adb/`, pairing survives container rebuilds.
+
+## Daily connect flow
+
+Each wireless debugging session exposes a fresh debug port on the phone.
+
+1. Open `Settings -> Developer options -> Wireless debugging`.
+2. Note the current debug address, for example `192.168.1.50:42341`.
+3. In the container terminal, connect:
+
+```bash
+./scripts/adb-wireless connect 192.168.1.50:42341
+```
+
+To confirm the device is visible:
+
+```bash
+./scripts/adb-wireless devices
+```
+
+## Build and test
+
+```bash
+./gradlew assembleDebug
+./gradlew installDebug
+./gradlew test
+./gradlew connectedAndroidTest
+```
+
+## Install more SDK packages later
+
+```bash
+sdkmanager --list | grep "platforms;android"
+sdkmanager "platforms;android-34" "build-tools;34.0.0"
+```
+
+The SDK directory is writable by the `vscode` user, so you can add packages from inside the container.
+
+## Troubleshooting
+
+- `adb: no devices/emulators found`: reconnect with the current debug address shown on the phone
+- Pairing stops working after a reset on the phone: remove the saved device from the phone and pair again
+- `sdk.dir` errors: rerun `Dev Containers: Rebuild Container` so the post-create step rewrites `local.properties`
+- Gradle cache is empty after reopening: make sure `.gradle-cache/` exists in the repo root and the container reopened successfully
+- ADB pairing did not persist: make sure `.android-adb/` exists in the repo root and is mounted into the container

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+{
+  "name": "Yomihon Android Dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "options": [
+      "--platform=linux/amd64"
+    ]
+  },
+  "runArgs": [
+    "--platform=linux/amd64"
+  ],
+  "remoteUser": "vscode",
+  "initializeCommand": "mkdir -p \"${localWorkspaceFolder}/.gradle-cache\" \"${localWorkspaceFolder}/.android-adb\"",
+  "containerEnv": {
+    "ANDROID_HOME": "/opt/android-sdk",
+    "ANDROID_SDK_ROOT": "/opt/android-sdk",
+    "GRADLE_USER_HOME": "/home/vscode/.gradle",
+    "JAVA_HOME": "/usr/lib/jvm/temurin-17-jdk-current"
+  },
+  "mounts": [
+    "source=${localWorkspaceFolder}/.gradle-cache,target=/home/vscode/.gradle,type=bind,consistency=cached",
+    "source=${localWorkspaceFolder}/.android-adb,target=/home/vscode/.android,type=bind,consistency=cached"
+  ],
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "mathiasfrohlich.Kotlin",
+        "naco-siren.gradle-language",
+        "vscjava.vscode-gradle",
+        "redhat.java",
+        "vscjava.vscode-java-pack"
+      ],
+      "settings": {
+        "android.sdk.path": "/opt/android-sdk",
+        "java.import.gradle.java.home": "/usr/lib/jvm/temurin-17-jdk-current",
+        "java.jdt.ls.java.home": "/usr/lib/jvm/temurin-17-jdk-current",
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+local_properties="${repo_root}/local.properties"
+user_gradle_properties="${HOME}/.gradle/gradle.properties"
+sdk_dir="/opt/android-sdk"
+
+mkdir -p "${repo_root}/.gradle-cache" "${repo_root}/.android-adb" "${HOME}/.android"
+touch "${HOME}/.android/repositories.cfg"
+
+if [[ -f "${local_properties}" ]]; then
+    tmp_file="$(mktemp)"
+    awk -v sdk_dir="${sdk_dir}" '
+        BEGIN { updated = 0 }
+        /^sdk\.dir=/ {
+            print "sdk.dir=" sdk_dir
+            updated = 1
+            next
+        }
+        { print }
+        END {
+            if (!updated) {
+                print "sdk.dir=" sdk_dir
+            }
+        }
+    ' "${local_properties}" > "${tmp_file}"
+    mv "${tmp_file}" "${local_properties}"
+else
+    printf 'sdk.dir=%s\n' "${sdk_dir}" > "${local_properties}"
+fi
+
+mkdir -p "$(dirname "${user_gradle_properties}")"
+
+tmp_file="$(mktemp)"
+if [[ -f "${user_gradle_properties}" ]]; then
+    awk '
+        BEGIN { skip = 0 }
+        /^# codex-devcontainer-start$/ { skip = 1; next }
+        /^# codex-devcontainer-end$/ { skip = 0; next }
+        skip == 0 { print }
+    ' "${user_gradle_properties}" > "${tmp_file}"
+else
+    : > "${tmp_file}"
+fi
+
+cat >> "${tmp_file}" <<'EOF'
+# codex-devcontainer-start
+# Container-local Gradle overrides for Docker Desktop stability.
+org.gradle.parallel=false
+org.gradle.vfs.watch=false
+org.gradle.workers.max=2
+org.gradle.jvmargs=-Xmx1536m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:MaxGCPauseMillis=200
+kotlin.daemon.jvmargs=-Xmx1024m -XX:+UseG1GC -XX:MaxMetaspaceSize=384m
+# codex-devcontainer-end
+EOF
+
+mv "${tmp_file}" "${user_gradle_properties}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Build files
 .gradle
+.gradle-cache/
 .kotlin
 build
+.android-adb/
 
 # IDE files
 *.iml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Before you start, please note that the ability to use following technologies is 
 ### Tools
 
 - [Android Studio](https://developer.android.com/studio)
+- [VS Code DevContainer workflow](./.devcontainer/README.md) for a containerized Android toolchain on macOS/Linux
 - Emulator or phone with developer options enabled to test changes.
 
 # Translations

--- a/scripts/adb-wireless
+++ b/scripts/adb-wireless
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/adb-wireless pair <host:port>
+  ./scripts/adb-wireless connect <host:port>
+  ./scripts/adb-wireless disconnect [host:port]
+  ./scripts/adb-wireless devices
+EOF
+}
+
+if ! command -v adb >/dev/null 2>&1; then
+    echo "adb is not installed in this shell."
+    exit 1
+fi
+
+command_name="${1:-}"
+
+case "${command_name}" in
+    pair)
+        endpoint="${2:-}"
+        if [[ -z "${endpoint}" ]]; then
+            usage
+            exit 1
+        fi
+        adb pair "${endpoint}"
+        ;;
+    connect)
+        endpoint="${2:-}"
+        if [[ -z "${endpoint}" ]]; then
+            usage
+            exit 1
+        fi
+        adb connect "${endpoint}"
+        adb devices -l
+        ;;
+    disconnect)
+        endpoint="${2:-}"
+        if [[ -n "${endpoint}" ]]; then
+            adb disconnect "${endpoint}"
+        else
+            adb disconnect
+        fi
+        adb devices -l
+        ;;
+    devices)
+        adb devices -l
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds DevContainer support for Android development so the full Android toolchain can run inside the container instead of on the host machine.

This setup is aimed at developing on macOS with VS Code + Docker Desktop and deploying to a physical Android device over wireless ADB.

## What changed

- Added a `.devcontainer/` setup for the repo
- Added an Android-focused DevContainer `Dockerfile`
- Added post-create setup to configure the Android SDK path automatically
- Added persistent mounts for:
  - Gradle cache
  - ADB pairing/client state
- Added a small `scripts/adb-wireless` helper for pairing/connect/disconnect flows
- Updated `.gitignore` for local DevContainer Android state
- Documented the workflow in `.devcontainer/README.md`
- Linked the DevContainer workflow from `CONTRIBUTING.md`

## Why

This makes it possible to contribute to the app without installing the Android SDK, Java, build tools, or Gradle on the host machine.

The goal is:
- host only needs VS Code + Docker Desktop
- Android build tooling lives inside the DevContainer
- deploy/debug happens on a real phone over Wi-Fi

## Notes

- The container is configured to run as `linux/amd64` on Apple Silicon because the Android Linux build tools used by Gradle are not reliably usable under native ARM for this workflow.
- ADB pairing state is persisted so wireless pairing survives container rebuilds.
- Gradle cache is persisted to avoid re-downloading dependencies after container rebuilds.

## Testing

Tested manually by:
- opening the repo in the DevContainer
- pairing an Android device with wireless debugging
- connecting via ADB from inside the container
- building/installing the app with Gradle
